### PR TITLE
fix(publish): remove ubuntu-latest aarch64 build from workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,8 +24,6 @@ jobs:
         include:
           - os: ubuntu-latest
             target: x86_64
-          - os: ubuntu-latest
-            target: aarch64
           - os: macos-latest
             target: x86_64
           - os: macos-latest


### PR DESCRIPTION
The ubuntu-latest aarch64 build was failing and is not needed. Keep only the required builds:
- ubuntu-latest x86_64
- macos-latest x86_64
- macos-latest aarch64